### PR TITLE
Bump version compatible with Amazon Aurora postgresql 13.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,7 @@
-FROM postgres:13.8 AS base
-
-# Mac などの arm 環境でビルドすると、次のエラーが発生する `clang++: error: unknown argument: '-ftrivial-auto-var-init=pattern'`
-# これは PLV8 のビルド時に発生するエラーで arm 環境で v3.0.0 の場合に起きる https://github.com/plv8/plv8/issues/444
-# そのため、PLV8 のバージョンが 3.0.0 のあいだは、docker build を実行する環境が x86_64 でなければならない。
-# Mac などの arm 環境からビルドするときには docker build --platform linux/amd64 のように、platform を指定すること。
-#
-# GitHub のコメントより、この事象は PLV8 のバージョンが v3.1 などでは解消していると思われる。
-# v3.0.0 以降で問題の解消を確認した際には、このコメントを削除する。
+FROM postgres:13.13-bullseye AS base
 
 FROM base AS build-pg_repack
-ENV PG_REPACK_VERSION 1.4.6
+ENV PG_REPACK_VERSION 1.4.7
 ENV buildDependencies "build-essential \
     ca-certificates \
     clang \
@@ -24,7 +16,7 @@ RUN apt-get update && \
     cd pg_repack; git checkout ver_${PG_REPACK_VERSION}; make; make install;
 
 FROM base AS build-plv8
-ENV PLV8_VERSION 3.0.0
+ENV PLV8_VERSION 3.1.8
 ENV buildDependencies "build-essential \
     ca-certificates \
     clang \
@@ -43,7 +35,7 @@ ENV buildDependencies "build-essential \
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ${buildDependencies} && \
     mkdir -p /tmp/build; \
-    curl -o /tmp/build/v${PLV8_VERSION}.tar.gz -SL "https://github.com/plv8/plv8/archive/v${PLV8_VERSION}.tar.gz"; \
+    curl -o /tmp/build/v${PLV8_VERSION}.tar.gz -SL "https://github.com/plv8/plv8/archive/refs/tags/v${PLV8_VERSION}.tar.gz"; \
     tar -xzf /tmp/build/v${PLV8_VERSION}.tar.gz -C /tmp/build/; \
     cd /tmp/build/plv8-${PLV8_VERSION} && make && make install; \
     strip /usr/lib/postgresql/${PG_MAJOR}/lib/plv8-${PLV8_VERSION}.so


### PR DESCRIPTION
## Background / Why (背景と理由)

現在の本番環境で利用している Amazon Aurora PostgreSQL 13.13 と同等の環境を用意する。

![スクリーンショット 2024-07-26 17 46 22](https://github.com/user-attachments/assets/bb54fda1-bd13-48e8-81bc-2f5edcb7086d)

## What (やったこと)

PostgreSQL の 13.13 化

それに伴い
拡張機能 pg_repack を 1.4.7 
拡張機能 plv8 を 3.1.8
へと変更した。

https://docs.aws.amazon.com/ja_jp/AmazonRDS/latest/AuroraPostgreSQLReleaseNotes/AuroraPostgreSQL.Extensions.html#AuroraPostgreSQL.Extensions.13

![スクリーンショット 2024-07-26 17 48 31](https://github.com/user-attachments/assets/5105a907-38d2-4bfe-93f9-4641969fa18c)

![スクリーンショット 2024-07-26 17 47 58](https://github.com/user-attachments/assets/9afeeef2-af2f-40d2-9d4d-bd2cddcb9886)
