### PR TITLE
postgres-plv8 のバージョンを 13.21 にあげる

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM postgres:13.13-bullseye AS base
+FROM postgres:13.21-bullseye AS base
 
 FROM base AS build-pg_repack
-ENV PG_REPACK_VERSION=1.4.7
+ENV PG_REPACK_VERSION=1.5.1
 ENV buildDependencies="build-essential \
     ca-certificates \
     clang \
@@ -16,7 +16,7 @@ RUN apt-get update && \
     cd pg_repack; git checkout ver_${PG_REPACK_VERSION}; make; make install;
 
 FROM base AS build-plv8
-ENV PLV8_VERSION=3.1.8
+ENV PLV8_VERSION=3.1.10
 ENV buildDependencies="build-essential \
     ca-certificates \
     clang \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM postgres:13.13-bullseye AS base
 
 FROM base AS build-pg_repack
-ENV PG_REPACK_VERSION 1.4.7
-ENV buildDependencies "build-essential \
+ENV PG_REPACK_VERSION=1.4.7
+ENV buildDependencies="build-essential \
     ca-certificates \
     clang \
     git \
@@ -16,8 +16,8 @@ RUN apt-get update && \
     cd pg_repack; git checkout ver_${PG_REPACK_VERSION}; make; make install;
 
 FROM base AS build-plv8
-ENV PLV8_VERSION 3.1.8
-ENV buildDependencies "build-essential \
+ENV PLV8_VERSION=3.1.8
+ENV buildDependencies="build-essential \
     ca-certificates \
     clang \
     curl \
@@ -48,7 +48,7 @@ COPY --from=build-pg_repack /usr/share/postgresql/ /usr/share/postgresql/
 COPY --from=build-plv8 /usr/lib/postgresql/ /usr/lib/postgresql/
 COPY --from=build-plv8 /usr/share/postgresql/ /usr/share/postgresql/
 
-ENV runtimeDependencies "libc++1"
+ENV runtimeDependencies="libc++1"
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ${runtimeDependencies} && \
     apt-get clean && \

--- a/README.md
+++ b/README.md
@@ -7,20 +7,20 @@ AWS に準じた postgreSQL - PLV8 のバージョンを作成する
 ### docker run
 
 ```
-docker run -e POSTGRES_HOST_AUTH_METHOD=trust -p 5432:5432 ghcr.io/diggle-jp/postgres-plv8/postgres:13.13-3.1.8
+docker run -e POSTGRES_HOST_AUTH_METHOD=trust -p 5432:5432 ghcr.io/diggle-jp/postgres-plv8/postgres:13.21-3.1.10
 ```
 
 ### docker-compose.yml
 
 ```
 db:
-  image: ghcr.io/diggle-jp/postgres-plv8/postgres:13.13-3.1.8
+  image: ghcr.io/diggle-jp/postgres-plv8/postgres:13.21-3.1.10
 ```
 
 ## How to update
 
 1. update Dockerfile
-2. make Release Tag `(postgres version)-(plv8 version)` e.g. `13.13-3.1.8`
+2. make Release Tag `(postgres version)-(plv8 version)` e.g. `13.21-3.1.10`
 3. add new Release to https://github.com/diggle-jp/postgres-plv8/releases
 
 # License


### PR DESCRIPTION
## Background / Why (背景と理由)

- JIRA: https://diggle.atlassian.net/browse/DEV-13090

Postgresのバージョンアップを行う

拡張機能のバージョンは、AWSで、PostgreSQL 13.21にてサポートされているバージョンに準拠
FYI: https://docs.aws.amazon.com/ja_jp/AmazonRDS/latest/AuroraPostgreSQLReleaseNotes/AuroraPostgreSQL.Extensions.html#AuroraPostgreSQL.Extensions.13


## What (やったこと)

1. Dockerfile構文の修正

"ENV key value" 形式は古く非推奨なので、"ENV key=value"形式に書き換えました。

FYI: https://docs.docker.com/reference/build-checks/legacy-key-value-format/


2. バージョンアップ

PostgreSQL -> 13.21

拡張機能
- pg_repack -> 1.5.1
- plv8 -> 3.1.10

※このPull Requestをmainブランチにマージした後、imageのリリースを行います。

## 主にレビューしていただきたい点

- コードに問題がないか
- サクッと〜
